### PR TITLE
Expands GraphQL & Graphiti dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,22 +61,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        swift: ["5.7", "5.8", "5.9", "5.10"]
-    steps:
-    - uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: ${{ matrix.swift }}
-    - uses: actions/checkout@v3
-    - name: Test
-      run: swift test --parallel
-
-  # Swift versions older than 5.7 don't have builds for 22.04. https://www.swift.org/download/ 
-  backcompat-ubuntu-20_04:
-    name: Test Swift ${{ matrix.swift }} on Ubuntu 20.04
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        swift: ["5.4", "5.5", "5.6"]
+        swift: ["5.8", "5.9", "5.10"]
     steps:
     - uses: swift-actions/setup-swift@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        swift: ["5.7", "5.8", "5.9", "5.10", "6.0"]
+        swift: ["5.7", "5.8", "5.9", "5.10"]
     steps:
     - uses: swift-actions/setup-swift@v2
       with:

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
         "state": {
           "branch": null,
-          "revision": "87649dbc3cdab0be0256c86235f2aec22ec1bfc1",
-          "version": "2.10.0"
+          "revision": "ec809df8cce95d6aea820f70f04067abc08080f2",
+          "version": "2.10.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
         .library(name: "GraphQLRxSwift", targets: ["GraphQLRxSwift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.0.0"),
-        .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", "2.0.0" ..< "4.0.0"),
+        .package(url: "https://github.com/GraphQLSwift/Graphiti.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.1.0"),
     ],
     targets: [


### PR DESCRIPTION
Since this package doesn't rely on any functionality that changed in GraphQL v3 or Graphiti v2, it simply expands the version requirement to include the new version.